### PR TITLE
patch: dialog - add dlg.profile_end RPC command

### DIFF
--- a/debian/patches/010_dialog_profile_end.patch
+++ b/debian/patches/010_dialog_profile_end.patch
@@ -1,0 +1,249 @@
+diff --git a/src/modules/dialog/dialog.c b/src/modules/dialog/dialog.c
+index e6ff0e9bc3..3afb13e3b0 100644
+--- a/src/modules/dialog/dialog.c
++++ b/src/modules/dialog/dialog.c
+@@ -2095,6 +2095,44 @@ static void internal_rpc_profile_print_dlgs(rpc_t *rpc, void *c, str *profile_na
+ 	lock_release(&profile->lock);
+ }
+ 
++/*!
++ * \brief Helper function that ends the dialogs belonging to a given profile via the RPC interface
++ * \see rpc_profile_end_dlgs
++ * \see rpc_profile_w_value_end_dlgs
++ * \param rpc RPC node that should be filled
++ * \param c RPC void pointer
++ * \param profile_name the given profile
++ * \param value the given profile value
++ */
++static void internal_rpc_profile_end_dlgs(rpc_t *rpc, void *c, str *profile_name,
++		str *value) {
++	dlg_profile_table_t *profile;
++
++	profile = search_dlg_profile( profile_name );
++	if (!profile) {
++		rpc->fault(c, 404, "Profile not found: %.*s",
++			profile_name->len, profile_name->s);
++		return;
++	}
++
++	/* go through the hash and print the dialogs */
++	if (profile->has_value==0)
++		value=NULL;
++
++	if (value == NULL) {
++		LM_INFO("End dialogs belonging to profile %.*s",
++				profile_name->len, profile_name->s);
++	} else {
++		LM_INFO("End dialogs belonging to profile %.*s with value %.*s",
++				profile_name->len, profile_name->s,
++				value->len, value->s);
++	}
++
++	if (dlg_end_by_profile(profile, value) != 0) {
++		LM_ERR("Problems ending dialogs");
++	}
++}
++
+ /*
+  * Wrapper around is_known_dlg().
+  */
+@@ -2132,6 +2170,9 @@ static const char *rpc_profile_get_size_doc[2] = {
+ static const char *rpc_profile_print_dlgs_doc[2] = {
+ 	"Lists all the dialogs belonging to a profile", 0
+ };
++static const char *rpc_profile_end_dlgs_doc[2] = {
++	"End all the dialogs belonging to a profile", 0
++};
+ static const char *rpc_dlg_bridge_doc[2] = {
+ 	"Bridge two SIP addresses in a call using INVITE(hold)-REFER-BYE mechanism:\
+  to, from, [outbound SIP proxy]", 0
+@@ -2242,6 +2283,18 @@ static void rpc_profile_print_dlgs(rpc_t *rpc, void *c) {
+ 	}
+ 	return;
+ }
++static void rpc_profile_end_dlgs(rpc_t *rpc, void *c) {
++	str profile_name = {NULL,0};
++	str value = {NULL,0};
++
++	if (rpc->scan(c, ".S", &profile_name) < 1) return;
++	if (rpc->scan(c, "*.S", &value) > 0) {
++		internal_rpc_profile_end_dlgs(rpc, c, &profile_name, &value);
++	} else {
++		internal_rpc_profile_end_dlgs(rpc, c, &profile_name, NULL);
++	}
++	return;
++}
+ static void rpc_dlg_bridge(rpc_t *rpc, void *c) {
+ 	str from = {NULL,0};
+ 	str to = {NULL,0};
+@@ -2280,6 +2333,7 @@ static rpc_export_t rpc_methods[] = {
+ 	{"dlg.end_dlg", rpc_end_dlg_entry_id, rpc_end_dlg_entry_id_doc, 0},
+ 	{"dlg.profile_get_size", rpc_profile_get_size, rpc_profile_get_size_doc, 0},
+ 	{"dlg.profile_list", rpc_profile_print_dlgs, rpc_profile_print_dlgs_doc, RET_ARRAY},
++	{"dlg.profile_end", rpc_profile_end_dlgs, rpc_profile_end_dlgs_doc, RET_ARRAY},
+ 	{"dlg.bridge_dlg", rpc_dlg_bridge, rpc_dlg_bridge_doc, 0},
+ 	{"dlg.terminate_dlg", rpc_dlg_terminate_dlg, rpc_dlg_terminate_dlg_doc, 0},
+ 	{0, 0, 0, 0}
+diff --git a/src/modules/dialog/dlg_profile.c b/src/modules/dialog/dlg_profile.c
+index ccf1c078bc..8c55af574b 100644
+--- a/src/modules/dialog/dlg_profile.c
++++ b/src/modules/dialog/dlg_profile.c
+@@ -41,6 +41,7 @@
+ #include "dlg_var.h"
+ #include "dlg_handlers.h"
+ #include "dlg_profile.h"
++#include "dlg_req_within.h"
+ 
+ 
+ /*! size of dialog profile hash */
+@@ -1042,6 +1043,133 @@ error:
+ }
+ 
+ 
++/*
++ * \brief End all the dialogs in a given profile, by value.
++ * \param profile The evaluated profile name.
++ * \param value The value constraint.
++ */
++
++int	dlg_end_by_profile(struct dlg_profile_table *profile,
++				   str *value)
++{
++	unsigned int		i = 0;
++	dlg_cell_t		*this_dlg = NULL;
++	struct dlg_profile_hash	*ph = NULL;
++	int ret = 0;
++
++	/* Private structure necessary for manipulating dialog
++         * timeouts outside of profile locks.  Admittedly, an
++         * ugly hack, but avoids some concurrency issues.
++         */
++
++	struct dlg_map_list {
++		unsigned int		h_id;
++		unsigned int		h_entry;
++		struct dlg_map_list	*next;
++	} *map_head, *map_scan, *map_scan_next;
++
++	map_head = NULL;
++
++	/* If the profile has no value, iterate through every
++	 * node and set its timeout.
++	 */
++
++	if(profile->has_value == 0 || value == NULL) {
++		lock_get(&profile->lock);
++
++		for(i = 0; i < profile->size; i ++) {
++			ph = profile->entries[i].first;
++
++			if(!ph) continue;
++
++			do {
++				struct dlg_map_list *d = malloc(sizeof(struct dlg_map_list));
++
++				if(!d)
++					goto error;
++
++				memset(d, 0, sizeof(struct dlg_map_list));
++
++				d->h_id = ph->dlg->h_id;
++				d->h_entry = ph->dlg->h_entry;
++
++				if(map_head == NULL)
++					map_head = d;
++				else {
++					d->next = map_head;
++					map_head = d;
++				}
++
++				ph = ph->next;
++			} while(ph != profile->entries[i].first);
++		}
++
++		lock_release(&profile->lock);
++	} else {
++		i = calc_hash_profile(value, NULL, profile);
++
++		lock_get(&profile->lock);
++
++		ph = profile->entries[i].first;
++
++		if(ph) {
++			do {
++				if(ph && value->len == ph->value.len &&
++						memcmp(value->s, ph->value.s, value->len) == 0) {
++					struct dlg_map_list *d = malloc(sizeof(struct dlg_map_list));
++
++					if(!d)
++						goto error;
++
++					memset(d, 0, sizeof(struct dlg_map_list));
++
++					d->h_id = ph->dlg->h_id;
++					d->h_entry = ph->dlg->h_entry;
++
++					if(map_head == NULL)
++						map_head = d;
++					else {
++						d->next = map_head;
++						map_head = d;
++					}
++				}
++
++				ph = ph->next;
++			} while(ph && ph != profile->entries[i].first);
++		}
++
++		lock_release(&profile->lock);
++	}
++
++	/* Walk the list and bulk-end calls */
++
++	for(map_scan = map_head; map_scan != NULL; map_scan = map_scan_next) {
++		map_scan_next = map_scan->next;
++
++		this_dlg = dlg_lookup(map_scan->h_entry, map_scan->h_id);
++
++		if(!this_dlg) {
++			LM_CRIT("Unable to find dialog %d:%d\n", map_scan->h_entry, map_scan->h_id);
++		} else {
++			ret = dlg_bye_all(this_dlg, NULL);
++			if(ret>=0) {
++				dlg_release(this_dlg);
++			}
++		}
++
++		free(map_scan);
++	}
++
++	return 0;
++error:
++	for(map_scan = map_head; map_scan != NULL; map_scan = map_scan_next) {
++		map_scan_next = map_scan->next;
++		free(map_scan);
++	}
++	return -1;
++}
++
++
+ /**
+  * json serialization of dialog profiles
+  */
+diff --git a/src/modules/dialog/dlg_profile.h b/src/modules/dialog/dlg_profile.h
+index 4837a1fec9..daa3986202 100644
+--- a/src/modules/dialog/dlg_profile.h
++++ b/src/modules/dialog/dlg_profile.h
+@@ -229,6 +229,12 @@ int dlg_set_ruri(sip_msg_t *msg);
+ int dlg_set_timeout_by_profile(struct dlg_profile_table *, str *, int);
+ 
+ /*!
++ * \brief End all dialogs within a profile.
++ */
++
++int dlg_end_by_profile(struct dlg_profile_table *, str *);
++
++/*!
+  * \brief Add dialog to a profile
+  * \param dlg dialog
+  * \param value value

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@
 007_skip_cdr.patch
 008_lcr_dump_gw.patch
 009_lcr_ping_gw_id.patch
+010_dialog_profile_end.patch


### PR DESCRIPTION
Add dlg.profile_end RPC command to end all dialogs belonging to a given profile (with value or without value).