### PR TITLE
pua_dialoginfo: shorten Trying state lifetime to 15 seconds

### DIFF
--- a/debian/patches/011_pua_trying_presentity.patch
+++ b/debian/patches/011_pua_trying_presentity.patch
@@ -1,0 +1,30 @@
+diff --git a/src/modules/pua_dialoginfo/pua_dialoginfo.c b/src/modules/pua_dialoginfo/pua_dialoginfo.c
+index f8d92b67fe..b412de9f55 100644
+--- a/src/modules/pua_dialoginfo/pua_dialoginfo.c
++++ b/src/modules/pua_dialoginfo/pua_dialoginfo.c
+@@ -63,6 +63,7 @@ MODULE_VERSION
+ #define DEF_CALLEE_TRYING 0
+ #define DEF_DISABLE_CALLER_PUBLISH_FLAG -1
+ #define DEF_DISABLE_CALLEE_PUBLISH_FLAG -1
++#define DEF_TRYING_STATE_LIFETIME 15
+ 
+ /* define PUA_DIALOGINFO_DEBUG to activate more verbose
+  * logging and dialog info callback debugging
+@@ -644,7 +645,7 @@ __dialog_created(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
+ 		dialog_publish_multi("Trying", dlginfo->pubruris_caller,
+ 				&(dlg->from_uri),
+ 				(include_req_uri)?&(dlg->req_uri):&(dlg->to_uri),
+-				&(dlg->callid), 1, dlginfo->lifetime,
++				&(dlg->callid), 1, DEF_TRYING_STATE_LIFETIME,
+ 				0, 0, 0, 0, (send_publish_flag==-1)?1:0);
+ 	}
+ 
+@@ -654,7 +655,7 @@ __dialog_created(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
+ 		dialog_publish_multi("Trying", dlginfo->pubruris_callee,
+ 				(include_req_uri)?&(dlg->req_uri):&(dlg->to_uri),
+ 				&(dlg->from_uri),
+-				&(dlg->callid), 0, dlginfo->lifetime,
++				&(dlg->callid), 0, DEF_TRYING_STATE_LIFETIME,
+ 				0, 0, 0, 0, (send_publish_flag==-1)?1:0);
+ 	}
+ }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@
 008_lcr_dump_gw.patch
 009_lcr_ping_gw_id.patch
 010_dialog_profile_end.patch
+011_pua_trying_presentity.patch


### PR DESCRIPTION
**Current problem:**

- Kamailio creates a new presentity entry as soon as _dlg_manage()_ is called and sends a PUBLISH with _Trying_ state and reaches to every active watcher via NOTIFY.
- If the call is discarded later in routing logic (with _send_reply(); exit;_), that entry persists in presentity table for dialog lifetime (currently set to 10800) and active watchers are not notified.
- This causes wrong BLF light state for 3 hours.

**Definitive fix:**

- Definitive fix would be not calling to _dlg_manage()_ if you are going to reject the call a few lines afterwards, but current bouncing logic needs decoupling initial dialog and second traverse before setting dlg_vars, to avoid overriding values of initial traverse.

**Current patch:**

- This easy patch mitigates this _Trying_ lock duration from 3 hours (BLF in red) to 15 seconds. _Trying_ state should be very brief, as normally a call will be rapidly updated to _early_ (18X response), _confirmed_ (2XX response) or _terminated_ (>300 response) state.

**Known limitation**:

- If an INVITE does not receive any 18X or definitive response in 15 seconds, someone monitoring caller user will have its BLF off.