### PR TITLE
tm: t_suspend() memleak fix

### DIFF
--- a/debian/patches/012_t_suspend_memleak.patch
+++ b/debian/patches/012_t_suspend_memleak.patch
@@ -1,0 +1,37 @@
+diff --git a/src/modules/tm/t_suspend.c b/src/modules/tm/t_suspend.c
+index a150829699..3fd75e7955 100644
+--- a/src/modules/tm/t_suspend.c
++++ b/src/modules/tm/t_suspend.c
+@@ -123,18 +123,23 @@ int t_suspend(struct sip_msg *msg,
+ 			LM_ERR("failed find UAC branch\n");
+ 			return -1;
+ 		}
+-		LM_DBG("found a a match with branch id [%d] - "
+-				"cloning reply message to t->uac[branch].reply\n", branch);
+ 
+-		sip_msg_len = 0;
+-		t->uac[branch].reply = sip_msg_cloner( msg, &sip_msg_len );
++		if (!t->uac[branch].reply) {
++			sip_msg_len = 0;
++			LM_DBG("found a match with branch id [%d] - "
++				"cloning reply message to t->uac[branch].reply\n", branch);
++			t->uac[branch].reply = sip_msg_cloner( msg, &sip_msg_len );
+ 
+-		if (! t->uac[branch].reply ) {
+-			LM_ERR("can't alloc' clone memory\n");
+-			return -1;
++			if (! t->uac[branch].reply ) {
++				LM_ERR("can't alloc' clone memory\n");
++				return -1;
++			}
++			t->uac[branch].end_reply = ((char*)t->uac[branch].reply) + sip_msg_len;
++		} else {
++			LM_DBG("found a match with branch id [%d] - "
++				"message already cloned to t->uac[branch].reply\n", branch);
++			// This can happen when suspending more than once in a reply.
+ 		}
+-		t->uac[branch].end_reply = ((char*)t->uac[branch].reply) + sip_msg_len;
+-
+ 		LM_DBG("saving transaction data\n");
+ 		t->uac[branch].reply->flags = msg->flags;
+ 		t->flags |= T_ASYNC_SUSPENDED;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@
 009_lcr_ping_gw_id.patch
 010_dialog_profile_end.patch
 011_pua_trying_presentity.patch
+012_t_suspend_memleak.patch


### PR DESCRIPTION
When suspending while already in t_continue when processing a reply / suspending twice in a reply.

Co-authored-by: Julien Chavanton <jchavanton@subspace.com>

Cherry-pick https://github.com/kamailio/kamailio/commit/09218156f3831ec9642d9ebf20d8668229ab16d6#diff-8da07585c54d8513481c3015b58c1df4247e3bc9657e8d1a54415e88523e3c8d