### PR TITLE
patch: backport delayed rtpengine module initialization

### DIFF
--- a/debian/patches/015_rtpengine_delayed_initialization.patch
+++ b/debian/patches/015_rtpengine_delayed_initialization.patch
@@ -1,0 +1,80 @@
+diff --git a/src/modules/rtpengine/rtpengine.c b/src/modules/rtpengine/rtpengine.c
+index 00f0f0aff1..488b6a9cc0 100644
+--- a/src/modules/rtpengine/rtpengine.c
++++ b/src/modules/rtpengine/rtpengine.c
+@@ -184,7 +184,7 @@ static struct rtpp_node *select_rtpp_node_new(str, str, int, struct rtpp_node **
+ static struct rtpp_node *select_rtpp_node_old(str, str, int, enum rtpe_operation);
+ static struct rtpp_node *select_rtpp_node(str, str, int, struct rtpp_node **, int, enum rtpe_operation);
+ static int is_queried_node(struct rtpp_node *, struct rtpp_node **, int);
+-static int build_rtpp_socks();
++static int build_rtpp_socks(int lmode, int rtest);
+ static char *send_rtpp_command(struct rtpp_node *, bencode_item_t *, int *);
+ static int get_extra_id(struct sip_msg* msg, str *id_str);
+ 
+@@ -1129,7 +1129,7 @@ static void rtpengine_rpc_reload(rpc_t* rpc, void* ctx)
+ 		return;
+ 	}
+ 
+-	if (build_rtpp_socks()) {
++	if (build_rtpp_socks(1, 1)) {
+ 		rpc->fault(ctx, 500, "Out of memory");
+ 		return;
+ 	}
+@@ -1143,7 +1143,7 @@ static int rtpengine_rpc_iterate(rpc_t* rpc, void* ctx, const str *rtpp_url,
+ 	int found = RPC_FOUND_NONE, err = 0;
+ 	int ret;
+ 
+-	if (build_rtpp_socks()) {
++	if (build_rtpp_socks(1, 1)) {
+ 		rpc->fault(ctx, 500, "Out of memory");
+ 		return -1;
+ 	}
+@@ -1581,7 +1581,12 @@ mod_init(void)
+ 	return 0;
+ }
+ 
+-static int build_rtpp_socks() {
++/**
++ * build rtp enigne sockets
++ * - lmode: locking mode (1 - lock if needed; 0 - no locking)
++ * - rtest: rtpengine testing (1 - test if active; 0 - no test done)
++ */
++static int build_rtpp_socks(int lmode, int rtest) {
+ 	int n, i;
+ 	char *cp;
+ 	struct addrinfo hints, *res;
+@@ -1693,7 +1698,7 @@ static int build_rtpp_socks() {
+ 
+ 			freeaddrinfo(res);
+ rptest:
+-			pnode->rn_disabled = rtpp_test(pnode, 0, 1);
++			if(rtest) pnode->rn_disabled = rtpp_test(pnode, 0, 1);
+ 		}
+ 		lock_release(rtpp_list->rset_lock);
+ 	}
+@@ -1773,8 +1778,14 @@ child_init(int rank)
+ 	memset(queried_nodes_ptr, 0, MAX_RTPP_TRIED_NODES * sizeof(struct rtpp_node*));
+ 
+ 	/* Iterate known RTP proxies - create sockets */
+-	if (build_rtpp_socks())
+-		return -1;
++	if(rank==PROC_SIPINIT) {
++		/* probe rtpengines only in first worker */
++		if (build_rtpp_socks(0, 1))
++			return -1;
++	} else {
++		if (build_rtpp_socks(0, 0))
++			return -1;
++	}
+ 
+ 	return 0;
+ }
+@@ -2726,7 +2749,7 @@ select_rtpp_node(str callid, str viabranch, int do_test, struct rtpp_node **quer
+ {
+ 	struct rtpp_node *node = NULL;
+ 
+-	if (build_rtpp_socks()) {
++	if (build_rtpp_socks(1, 0)) {
+ 		LM_ERR("out of memory\n");
+ 		return NULL;
+ 	}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@
 012_t_suspend_memleak.patch
 013_rtpengine_callid_skip_proxy_tag.patch
 014_uac_replace_display_name_fix.patch
+015_rtpengine_delayed_initialization.patch


### PR DESCRIPTION
This is a backport from 3d4813001052497d21804586d643697f7a68aee8 commit in kamailio project to delay initialization of rtpengine nodes until modules are loaded.

Without this changes, some modules like evapi didn't bind their listening ports until all rtpengine nodes were tested.