### PR TITLE
patch: increase ipops from 32 to 64 addresses

### DIFF
--- a/debian/patches/016_ipops_increase_dns_recs.patch
+++ b/debian/patches/016_ipops_increase_dns_recs.patch
@@ -1,0 +1,13 @@
+diff --git a/src/modules/ipops/ipops_pv.c b/src/modules/ipops/ipops_pv.c
+index 6e9d86b5a6..e033c47031 100644
+--- a/src/modules/ipops/ipops_pv.c
++++ b/src/modules/ipops/ipops_pv.c
+@@ -37,7 +37,7 @@
+ 
+ 
+ #define PV_DNS_ADDR 64
+-#define PV_DNS_RECS 32
++#define PV_DNS_RECS 64
+ 
+ typedef struct _sr_dns_record {
+ 	int type;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@
 013_rtpengine_callid_skip_proxy_tag.patch
 014_uac_replace_display_name_fix.patch
 015_rtpengine_delayed_initialization.patch
+016_ipops_increase_dns_recs.patch


### PR DESCRIPTION
Easy patch to increase ipops module results from 32 to 64 addresses.