### PR TITLE
patch: disconnect from redis sentinel after retrieving master address

### DIFF
--- a/debian/patches/017_redis_sentinel_free_connection.patch
+++ b/debian/patches/017_redis_sentinel_free_connection.patch
@@ -1,0 +1,50 @@
+diff --git a/src/modules/ndb_redis/redis_client.c b/src/modules/ndb_redis/redis_client.c
+index c9280991ff..f16571da06 100644
+--- a/src/modules/ndb_redis/redis_client.c
++++ b/src/modules/ndb_redis/redis_client.c
+@@ -199,6 +199,7 @@ int redisc_init(void)
+ 							port = atoi(res->element[1]->str);
+ 							LM_DBG("sentinel replied: %s:%d\n", addr, port);
+ 							srvfound = 1;
++							freeReplyObject(res);
+ 						}
+ 					} else {
+ 						res = redisCommand(
+@@ -219,12 +220,14 @@ int redisc_init(void)
+ 										break;
+ 									}
+ 								}
++								freeReplyObject(res);
+ 							}
+ 							LOG(ndb_redis_debug, "slave for %s: %s:%d\n",
+ 									sentinel_group, addr, port);
+ 							srvfound = 1;
+ 						}
+ 					}
++					redisFree(redis);
+ 				}
+ 				if(srvfound == 1) {
+ 					break;
+@@ -557,6 +560,7 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
+ 						LOG(ndb_redis_debug, "sentinel replied: %s:%d\n", addr,
+ 								port);
+ 						srvfound = 1;
++						freeReplyObject(res);
+ 					}
+ 				} else {
+ 					res = redisCommand(
+@@ -577,12 +581,14 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
+ 									break;
+ 								}
+ 							}
++							freeReplyObject(res);
+ 						}
+ 						LOG(ndb_redis_debug, "slave for %s: %s:%d\n",
+ 								sentinel_group, addr, port);
+ 						srvfound = 1;
+ 					}
+ 				}
++				redisFree(redis);
+ 			}
+ 			if(srvfound == 1) {
+ 				break;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@
 009_lcr_ping_gw_id.patch
 010_dialog_profile_end.patch
 016_ipops_increase_dns_recs.patch
+017_redis_sentinel_free_connection.patch


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Add free function for Redis Sentinel connections and responses. Otherwise new connections are created to sentinel without closing existing ones when a problem with redis server occurs.



